### PR TITLE
Fix for JENKINS-14833

### DIFF
--- a/src/main/java/jenkins/plugins/coverity/CoverityLauncherDecorator.java
+++ b/src/main/java/jenkins/plugins/coverity/CoverityLauncherDecorator.java
@@ -12,6 +12,7 @@
 package jenkins.plugins.coverity;
 
 import com.coverity.ws.v3.CovRemoteServiceException_Exception;
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -144,12 +145,13 @@ public class CoverityLauncherDecorator extends LauncherDecorator {
 				covBuild = new FilePath(node.getChannel(), home).child("bin").child(covBuild).getRemote();
 			}
 
+            EnvVars env = build.getEnvironment(listener);
 			List<String> args = new ArrayList<String>();
 			args.add(covBuild);
 			args.add("--dir");
 			args.add(temp.getRemote());
 			if(ii.getBuildArguments() != null) {
-				for(String arg : Util.tokenize(ii.getBuildArguments())) {
+				for(String arg : Util.tokenize(env.expand(ii.getBuildArguments()))) {
 					args.add(arg);
 				}
 			}

--- a/src/main/java/jenkins/plugins/coverity/CoverityPublisher.java
+++ b/src/main/java/jenkins/plugins/coverity/CoverityPublisher.java
@@ -253,6 +253,7 @@ public class CoverityPublisher extends Recorder {
 			home = new CoverityInstallation(invocationAssistance.getSaOverride()).forEnvironment(build.getEnvironment(listener)).getHome();
 		}
 
+        EnvVars env = build.getEnvironment(listener);
 		Set<String> analyzedLanguages = new HashSet<String>();
 
 		for(CIMStream cimStream : getCimStreams()) {
@@ -307,7 +308,7 @@ public class CoverityPublisher extends Recorder {
 
 					listener.getLogger().println("[Coverity] cmd so far is: " + cmd.toString());
 					if(invocationAssistance.getAnalyzeArguments() != null) {
-						for(String arg : Util.tokenize(invocationAssistance.getAnalyzeArguments())) {
+						for(String arg : Util.tokenize(env.expand(invocationAssistance.getAnalyzeArguments()))) {
 							cmd.add(arg);
 						}
 					}
@@ -345,8 +346,8 @@ public class CoverityPublisher extends Recorder {
 				cmd.add("--user");
 				cmd.add(cim.getUser());
 
-				if(invocationAssistance.getCommitArguments() != null) {
-					for(String arg : Util.tokenize(invocationAssistance.getCommitArguments())) {
+                                if(invocationAssistance.getCommitArguments() != null) {
+					for(String arg : Util.tokenize(env.expand(invocationAssistance.getCommitArguments()))) {
 						cmd.add(arg);
 					}
 				}


### PR DESCRIPTION
I believe this patch fixes JENKINS-14833 by passing the extra command line arguments through the environment expander before adding them to the command line.
