### PR TITLE
Jenkins 17963

### DIFF
--- a/src/main/java/jenkins/plugins/coverity/CoverityBuildAction.java
+++ b/src/main/java/jenkins/plugins/coverity/CoverityBuildAction.java
@@ -16,6 +16,7 @@ import com.coverity.ws.v5.MergedDefectDataObj;
 import hudson.model.AbstractBuild;
 import hudson.model.Action;
 import hudson.model.Hudson;
+import hudson.Util;
 
 import java.io.IOException;
 import java.util.List;
@@ -78,7 +79,7 @@ public class CoverityBuildAction implements Action {
 	}
 
 	public String getDisplayName() {
-		return "Coverity Defects (" + getId() + ")";
+		return "Coverity Defects";
 	}
 
 	public String getUrlName() {
@@ -86,7 +87,7 @@ public class CoverityBuildAction implements Action {
 	}
 
 	/**
-	 * ID of the CIM project used for ths build
+	 * ID of the CIM project used for this build
 	 *
 	 * @return
 	 */
@@ -95,7 +96,7 @@ public class CoverityBuildAction implements Action {
 	}
 
 	public String getUrl() {
-		return build.getUrl() + getUrlName();
+		return build.getUrl() + Util.rawEncode(getUrlName());
 	}
 
 	public String getId() {

--- a/src/main/java/jenkins/plugins/coverity/CoverityPublisher.java
+++ b/src/main/java/jenkins/plugins/coverity/CoverityPublisher.java
@@ -500,7 +500,7 @@ public class CoverityPublisher extends Recorder {
 
 					String rootUrl = Hudson.getInstance().getRootUrl();
 					if(rootUrl != null) {
-						listener.getLogger().println("Coverity details: " + Hudson.getInstance().getRootUrl() + build.getUrl() + action.getUrlName());
+						listener.getLogger().println("Coverity details: " + Hudson.getInstance().getRootUrl() + build.getUrl() + Util.rawEncode(action.getUrlName()));
 					}
 
 				} catch(CovRemoteServiceException_Exception e) {

--- a/src/main/resources/jenkins/plugins/coverity/CoverityBuildAction/index.jelly
+++ b/src/main/resources/jenkins/plugins/coverity/CoverityBuildAction/index.jelly
@@ -9,7 +9,7 @@
  *    Coverity, Inc - initial implementation and documentation
 -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson">
-    <l:layout title="${it.build.parent.displayName} #${it.build.number} Coverity Defects">
+     <l:layout title="Coverity Defects : ${it.build.project.displayName} ${it.build.displayName}">
         <st:include page="sidepanel.jelly" it="${it.build}" optional="true"/>
         <l:main-panel>
 


### PR DESCRIPTION
This escapes the strings that make up the URL displayed in the UI.
Removes the id data from the sidebar link (As it's is somewhat large)
Modifies the title of the coverity build page
