### PR TITLE
Threshold defect hook and COVERITY_CIDS expansion token for mail plugins to send mails about cids from build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,12 +129,17 @@
             <version>${jenkins.version}</version>
             <scope>test</scope>
         </dependency>
-		<dependency>
-			<groupId>org.jenkins-ci.plugins</groupId>
-			<artifactId>mailer</artifactId>
-			<version>1.4</version>
-			<scope>compile</scope>
-		</dependency>
+	<dependency>
+	    <groupId>org.jenkins-ci.plugins</groupId>
+	    <artifactId>mailer</artifactId>
+	    <version>1.4</version>
+	    <scope>compile</scope>
+	</dependency>
+	<dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>token-macro</artifactId>
+            <version>1.10</version>
+        </dependency>
     </dependencies>
 
 

--- a/src/main/java/jenkins/plugins/coverity/BuildCIDSTokenMacro.java
+++ b/src/main/java/jenkins/plugins/coverity/BuildCIDSTokenMacro.java
@@ -1,0 +1,29 @@
+package jenkins.plugins.coverity;
+
+import hudson.Extension;
+import hudson.model.AbstractBuild;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;
+import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
+import jenkins.plugins.coverity.analysis.CoverityData;
+import jenkins.plugins.coverity.CoverityBuildAction;
+
+@Extension
+public class BuildCIDSTokenMacro extends DataBoundTokenMacro {
+
+    @Override
+    public boolean acceptsMacroName (String macroName) {
+        return macroName.equals ("COVERITY_CIDS");
+    }
+
+    @Override
+    public String evaluate (AbstractBuild<?, ?> context, TaskListener listener, String macroName)
+	throws MacroEvaluationException
+    {
+	CoverityData data = context.getAction (CoverityData.class);
+	CoverityBuildAction build = context.getAction (CoverityBuildAction.class);
+	if (data == null || build == null)
+	    return "None";
+	return data.getCidString (build);
+    }
+}

--- a/src/main/java/jenkins/plugins/coverity/BuildThreshold.java
+++ b/src/main/java/jenkins/plugins/coverity/BuildThreshold.java
@@ -1,0 +1,30 @@
+package jenkins.plugins.coverity;
+
+import hudson.model.Result;
+import hudson.model.Descriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class BuildThreshold {
+
+    private int value;
+    private Result type;
+
+    @DataBoundConstructor
+    public BuildThreshold (int thresholdValue, String buildType)
+	throws Descriptor.FormException
+    {
+	this.value = thresholdValue;
+	if (buildType.equals ("unstable"))
+	    this.type = Result.UNSTABLE;
+	else if (buildType.equals ("failure"))
+	    this.type = Result.FAILURE;
+    }
+
+    public int getThresholdValue () {
+	return this.value;
+    }
+
+    public Result getType () {
+	return this.type;
+    }
+}

--- a/src/main/java/jenkins/plugins/coverity/CoverityBuildAction.java
+++ b/src/main/java/jenkins/plugins/coverity/CoverityBuildAction.java
@@ -73,6 +73,15 @@ public class CoverityBuildAction implements Action {
                 instance.getHost(), instance.getPort(), instance.getProjectKey(projectId), defect.getCid());
     }
 
+    /**
+     * Returns the URL to the page for this defect in the CIM instance.
+     */
+    public String getURL(Long defect) throws IOException, CovRemoteServiceException_Exception {
+        CIMInstance instance = Hudson.getInstance().getDescriptorByType(CoverityPublisher.DescriptorImpl.class).getInstance(cimInstance);
+        return String.format("http://%s:%d/sourcebrowser.htm?projectId=%s&mergedDefectId=%d",
+			     instance.getHost(), instance.getPort(), instance.getProjectKey(projectId), defect.longValue ());
+    }
+
     public String getIconFileName() {
         return "/plugin/coverity/icons/coverity-logo-400px.png";
     }

--- a/src/main/java/jenkins/plugins/coverity/CoverityPublisher.java
+++ b/src/main/java/jenkins/plugins/coverity/CoverityPublisher.java
@@ -92,6 +92,12 @@ public class CoverityPublisher extends Recorder {
      */
     private final boolean hideChart;
     private final CoverityMailSender mailSender;
+    /**
+     * Threshold build hooks on defect numbers
+     */
+    private final BuildThreshold threshold;
+    private final boolean thresholdHookActive;
+    private List<Long> previous;
 
     @DataBoundConstructor
     public CoverityPublisher(List<CIMStream> cimStreams,
@@ -104,7 +110,8 @@ public class CoverityPublisher extends Recorder {
                              String cimInstance,
                              String project,
                              String stream,
-                             DefectFilters defectFilters) {
+                             DefectFilters defectFilters,
+			     BuildThreshold thresholdHook) {
         this.cimStreams = cimStreams;
         this.invocationAssistance = invocationAssistance;
         this.failBuild = failBuild;
@@ -116,6 +123,8 @@ public class CoverityPublisher extends Recorder {
         this.project = project;
         this.stream = stream;
         this.defectFilters = defectFilters;
+	this.threshold = thresholdHook;
+	this.thresholdHookActive = thresholdHook == null ? false : true;
 
         if(isOldDataPresent()) {
             logger.info("Old data format detected. Converting to new format.");
@@ -212,6 +221,22 @@ public class CoverityPublisher extends Recorder {
             return new ArrayList<CIMStream>();
         }
         return cimStreams;
+    }
+
+    public boolean getThresholdHookActive () {
+	return this.thresholdHookActive;
+    }
+
+    public BuildThreshold getBuildThreshold () {
+	return this.threshold;
+    }
+
+    public List<Long> getPreviousCids () {
+	return this.previous;
+    }
+
+    public void setPreviousCids (List<Long> defects) {
+	this.previous = defects;
     }
 
     @Override

--- a/src/main/java/jenkins/plugins/coverity/analysis/CoverityData.java
+++ b/src/main/java/jenkins/plugins/coverity/analysis/CoverityData.java
@@ -1,0 +1,86 @@
+package jenkins.plugins.coverity.analysis;
+
+import hudson.Functions;
+import hudson.model.AbstractBuild;
+import hudson.model.Action;
+import hudson.model.Api;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+import jenkins.plugins.coverity.CoverityBuildAction;
+
+import java.io.Serializable;
+import java.util.*;
+
+@ExportedBean(defaultVisibility = 999)
+public class CoverityData implements Action, Serializable, Cloneable {
+    private static final long serialVersionUID = 1L;
+    private List<Long> previous;
+    private List<Long> now;
+
+    public CoverityData (List<Long> previous, List<Long> now) {
+	this.previous = previous;
+	this.now = now;
+    }
+
+    @Exported
+    public String getCidString (CoverityBuildAction build) {
+	String retval = "Coverity Stream Diff:\n";
+	retval += "\tTotal defects found: [" + this.now.size () +
+	    "] Previous number of defects [" +  this.previous.size () + "]\n";
+	if (this.now.size () == this.previous.size ())
+	    retval += "\tNo Change!";
+	else {
+	    for (Long i : this.now) {
+		boolean found = false;
+		for (Long y : this.previous) {
+		    if (y.longValue () == i.longValue ()) {
+			found = true;
+			break;
+		    }
+		}
+		if (!found) {
+		    try {
+			String url = build.getURL (i);
+			retval += "\t ++ " + i.longValue () + " " + url + "\n";
+		    } catch (Exception e) {
+			// ...
+		    }
+		}
+	    }
+	    for (Long i : this.previous) {
+		boolean found = false;
+		for (Long y : this.now) {
+		    if (y.longValue () == i.longValue ()) {
+			found = true;
+			break;
+		    }
+		}
+		if (!found) {
+		    try {
+			String url = build.getURL (i);
+			retval += "\t -- " + i.longValue () + " " + url + "\n";
+		    } catch (Exception e) {
+			// ...
+		    }
+		}
+	    }
+	}
+	return retval;
+    }
+
+    public Api getApi () {
+        return new Api (this);
+    }
+
+    public String getDisplayName () {
+        return "Coverity Build Data";
+    }
+
+    public String getUrlName() {
+        return "coverity";
+    }
+
+    public String getIconFileName () {
+	return Functions.getResourcePath()+"/plugin/coverity/icons/coverity-logo.gif";
+    }
+}

--- a/src/main/java/jenkins/plugins/coverity/analysis/FresnoToolHandler.java
+++ b/src/main/java/jenkins/plugins/coverity/analysis/FresnoToolHandler.java
@@ -20,6 +20,7 @@ import jenkins.plugins.coverity.CoverityLauncherDecorator;
 import jenkins.plugins.coverity.CoverityPublisher;
 import jenkins.plugins.coverity.CoverityTempDir;
 import jenkins.plugins.coverity.InvocationAssistance;
+import jenkins.plugins.coverity.BuildThreshold;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -165,7 +166,7 @@ public class FresnoToolHandler extends CoverityToolHandler {
 
                     boolean useDataPort = cim.getDataPort() != 0;
 
-                    List<String> cmd = new ArrayList<String>();
+		    List<String> cmd = new ArrayList<String>();
                     cmd.add(covCommitDefects);
                     cmd.add("--dir");
                     cmd.add(temp.getTempDir().getRemote());
@@ -283,12 +284,26 @@ public class FresnoToolHandler extends CoverityToolHandler {
                                 build.setResult(Result.FAILURE);
                             }
                         }
+			if (publisher.getThresholdHookActive ()) {
+			    BuildThreshold bs = publisher.getBuildThreshold ();
+			    listener.getLogger().println("[Coverity] Threshold hook active value: " + bs.getThresholdValue ());
+			    if (matchingDefects.size() > bs.getThresholdValue ()) {
+				build.setResult (bs.getType ());
+			    }
+			}
                     } else {
                         listener.getLogger().println("[Coverity] No defects matched all filters.");
                     }
 
+		    List<Long> previous = publisher.getPreviousCids ();
+		    if (previous == null)
+			previous = new ArrayList<Long> ();
+		    publisher.setPreviousCids (matchingDefects);
+
                     CoverityBuildAction action = new CoverityBuildAction(build, cimStream.getProject(), cimStream.getStream(), cimStream.getInstance(), matchingDefects);
-                    build.addAction(action);
+		    CoverityData bdata = new CoverityData (previous, matchingDefects);
+		    build.addAction (bdata);
+                    build.addAction (action);
 
                     if(!matchingDefects.isEmpty() && publisher.getMailSender() != null) {
                         publisher.getMailSender().execute(action, listener);

--- a/src/main/resources/jenkins/plugins/coverity/CoverityPublisher/config.jelly
+++ b/src/main/resources/jenkins/plugins/coverity/CoverityPublisher/config.jelly
@@ -246,6 +246,32 @@
 					</f:entry>
 				</f:optionalBlock>
 
+                                <tr>
+				  <td class="setting-name" colspan="3">
+				    <f:block>
+				      <table>
+					<f:optionalBlock name="thresholdHook" field="thresholdHook" title="Threshold number of defects">
+					  <f:entry title="Threshold defect value">
+					    <f:textbox name="thresholdValue" field="thresholdValue"/>
+					  </f:entry>
+					  <f:entry name="buildStatus" title="Choose build status on threshold" field="buildType">
+					    <select name="buildType">
+					      <option value="unstable">Unstable Build</option>
+					      <option value="failure">Fail Build</option>
+					    </select>
+					  </f:entry>
+					</f:optionalBlock>
+				      </table>
+				    </f:block>
+                                  </td>
+				  <td class="setting-help">
+				    <a href="#" class="help-button"
+				       helpURL="${rootURL}/descriptor/jenkins.plugins.coverity.CoverityPublisher/help/thresholdHook">
+				      <img src="${imagesURL}/16x16/help.gif" alt="Help for feature: ${title}"/>
+				    </a>
+				  </td>
+				</tr>
+				<f:helpArea/>
 				<tr>
 					<td class="setting-name" colspan="3">
 						<f:checkbox field="failBuild"/>

--- a/src/main/resources/jenkins/plugins/coverity/CoverityPublisher/help-thresholdHook.html
+++ b/src/main/resources/jenkins/plugins/coverity/CoverityPublisher/help-thresholdHook.html
@@ -1,0 +1,13 @@
+<!--
+
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    NYSE Euronext - Philip Herron - redbrain@gcc.gnu.org
+-->
+<div>
+  Mark the build unstable of failed if the total number of found defects exceeds the threshold.
+</div>


### PR DESCRIPTION
```
- Threshold number of defects hook, change build status
- Expansion Token $COVERITY_CIDS lists cids from build, next builds will only list _new_ cids not matching any from the previous build.
```
