### PR TITLE
Fixed spelling of command line argument --certs

### DIFF
--- a/src/main/java/jenkins/plugins/coverity/CoverityTool/CoverityCommand.java
+++ b/src/main/java/jenkins/plugins/coverity/CoverityTool/CoverityCommand.java
@@ -28,7 +28,7 @@ public abstract class CoverityCommand extends Command {
     protected static final String useSslArg = "--ssl";
     private static final String onNewCertArg = "--on-new-cert";
     private static final String trustArg = "trust";
-    private static final String certArg = "--cert";
+    private static final String certArg = "--certs";
 
     public CoverityCommand(@Nonnull String command, AbstractBuild<?, ?> build, Launcher launcher, TaskListener listener, CoverityPublisher publisher, String home, EnvVars envVars) {
         super(build, launcher, listener, publisher, envVars);

--- a/src/main/java/jenkins/plugins/coverity/CoverityTool/CoverityCommand.java
+++ b/src/main/java/jenkins/plugins/coverity/CoverityTool/CoverityCommand.java
@@ -28,7 +28,7 @@ public abstract class CoverityCommand extends Command {
     protected static final String useSslArg = "--ssl";
     private static final String onNewCertArg = "--on-new-cert";
     private static final String trustArg = "trust";
-    private static final String certArg = "--certs";
+    private static final String certArg = "--cert";
 
     public CoverityCommand(@Nonnull String command, AbstractBuild<?, ?> build, Launcher launcher, TaskListener listener, CoverityPublisher publisher, String home, EnvVars envVars) {
         super(build, launcher, listener, publisher, envVars);

--- a/src/test/java/jenkins/plugins/coverity/CoverityTool/CovCommitDefectsCommandTest.java
+++ b/src/test/java/jenkins/plugins/coverity/CoverityTool/CovCommitDefectsCommandTest.java
@@ -110,7 +110,7 @@ public class CovCommitDefectsCommandTest extends CommandTestBase {
         Command covCommitDefectsCommand = new CovCommitDefectsCommand(build, launcher, listener, publisher, StringUtils.EMPTY, envVars, cimStream, cimInstance, CoverityVersion.VERSION_JASPER);
         setExpectedArguments(new String[] {
                 "cov-commit-defects", "--dir", "TestDir", "--host", "Localhost",
-                "--ssl", "--dataport", "1234", "--on-new-cert", "trust", "--certs", "TestCertFile",
+                "--ssl", "--dataport", "1234", "--on-new-cert", "trust", "--cert", "TestCertFile",
                  "--stream", "TestStream", "--user", "TestUser"
         });
         covCommitDefectsCommand.runCommand();
@@ -168,7 +168,7 @@ public class CovCommitDefectsCommandTest extends CommandTestBase {
         Command covCommitDefectsCommand = new CovCommitDefectsCommand(build, launcher, listener, publisher, StringUtils.EMPTY, envVars, cimStream, cimInstance, CoverityVersion.VERSION_JASPER);
         setExpectedArguments(new String[] {
                 "cov-commit-defects", "--dir", "TestDir", "--host", "Localhost",
-                "--ssl", "--https-port", "8080", "--on-new-cert", "trust", "--certs", "TestCertFile",
+                "--ssl", "--https-port", "8080", "--on-new-cert", "trust", "--cert", "TestCertFile",
                 "--stream", "TestStream", "--user", "TestUser"
         });
         covCommitDefectsCommand.runCommand();

--- a/src/test/java/jenkins/plugins/coverity/CoverityTool/CovCommitDefectsCommandTest.java
+++ b/src/test/java/jenkins/plugins/coverity/CoverityTool/CovCommitDefectsCommandTest.java
@@ -110,7 +110,7 @@ public class CovCommitDefectsCommandTest extends CommandTestBase {
         Command covCommitDefectsCommand = new CovCommitDefectsCommand(build, launcher, listener, publisher, StringUtils.EMPTY, envVars, cimStream, cimInstance, CoverityVersion.VERSION_JASPER);
         setExpectedArguments(new String[] {
                 "cov-commit-defects", "--dir", "TestDir", "--host", "Localhost",
-                "--ssl", "--dataport", "1234", "--on-new-cert", "trust", "--cert", "TestCertFile",
+                "--ssl", "--dataport", "1234", "--on-new-cert", "trust", "--certs", "TestCertFile",
                  "--stream", "TestStream", "--user", "TestUser"
         });
         covCommitDefectsCommand.runCommand();
@@ -168,7 +168,7 @@ public class CovCommitDefectsCommandTest extends CommandTestBase {
         Command covCommitDefectsCommand = new CovCommitDefectsCommand(build, launcher, listener, publisher, StringUtils.EMPTY, envVars, cimStream, cimInstance, CoverityVersion.VERSION_JASPER);
         setExpectedArguments(new String[] {
                 "cov-commit-defects", "--dir", "TestDir", "--host", "Localhost",
-                "--ssl", "--https-port", "8080", "--on-new-cert", "trust", "--cert", "TestCertFile",
+                "--ssl", "--https-port", "8080", "--on-new-cert", "trust", "--certs", "TestCertFile",
                 "--stream", "TestStream", "--user", "TestUser"
         });
         covCommitDefectsCommand.runCommand();

--- a/src/test/java/jenkins/plugins/coverity/CoverityTool/CovManageHistoryCommandTest.java
+++ b/src/test/java/jenkins/plugins/coverity/CoverityTool/CovManageHistoryCommandTest.java
@@ -137,7 +137,7 @@ public class CovManageHistoryCommandTest extends CommandTestBase {
         setExpectedArguments(new String[] {
                 "cov-manage-history", "--dir", "TestDir", "download", "--host", "Localhost",
                 "--port", "8080", "--stream", "TestStream", "--ssl", "--on-new-cert", "trust",
-                "--certs", "TestCertFile", "--user", "TestUser", "--merge"
+                "--cert", "TestCertFile", "--user", "TestUser", "--merge"
         });
         covManageHistoryCommand.runCommand();
         assertEquals("TestPassword", envVars.get("COVERITY_PASSPHRASE"));

--- a/src/test/java/jenkins/plugins/coverity/CoverityTool/CovManageHistoryCommandTest.java
+++ b/src/test/java/jenkins/plugins/coverity/CoverityTool/CovManageHistoryCommandTest.java
@@ -137,7 +137,7 @@ public class CovManageHistoryCommandTest extends CommandTestBase {
         setExpectedArguments(new String[] {
                 "cov-manage-history", "--dir", "TestDir", "download", "--host", "Localhost",
                 "--port", "8080", "--stream", "TestStream", "--ssl", "--on-new-cert", "trust",
-                "--cert", "TestCertFile", "--user", "TestUser", "--merge"
+                "--certs", "TestCertFile", "--user", "TestUser", "--merge"
         });
         covManageHistoryCommand.runCommand();
         assertEquals("TestPassword", envVars.get("COVERITY_PASSPHRASE"));


### PR DESCRIPTION
The plugin tries to call the Coverity binaries with command line argument --cert instead of --certs.