### PR TITLE
Multiple Coverity Action Resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 target
 work
 .idea
+.settings/
+.vscode/
+.classpath
+.factorypath
+.project

--- a/src/main/java/jenkins/plugins/coverity/CoverityViewResultsPublisher.java
+++ b/src/main/java/jenkins/plugins/coverity/CoverityViewResultsPublisher.java
@@ -74,8 +74,7 @@ public class CoverityViewResultsPublisher extends Recorder implements SimpleBuil
 
         try {
             ViewIssuesReader reader = new ViewIssuesReader(run, listener.getLogger(), this);
-            reader.getIssuesFromConnectView();
-            final CoverityBuildAction buildAction = run.getAction(CoverityBuildAction.class);
+            final CoverityBuildAction buildAction = reader.getIssuesFromConnectView();
             if (abortPipeline && buildAction.getDefects().size() > 0) {
                 logger.println("[Coverity] Coverity issues were found and abortPipeline was set to true, throwing abort exception.");
                 throw new AbortException("Coverity issues were found");

--- a/src/main/java/jenkins/plugins/coverity/ws/ViewIssuesReader.java
+++ b/src/main/java/jenkins/plugins/coverity/ws/ViewIssuesReader.java
@@ -40,7 +40,7 @@ public class ViewIssuesReader {
         this.publisher = publisher;
     }
 
-    public void getIssuesFromConnectView() throws Exception {
+    public CoverityBuildAction getIssuesFromConnectView() throws Exception {
         CIMInstance instance = publisher.getInstance();
 
         if (instance != null) {
@@ -53,6 +53,9 @@ public class ViewIssuesReader {
             if(StringUtils.isNotEmpty(rootUrl)) {
                 outputLogger.println("Coverity details: " + rootUrl + run.getUrl() + action.getUrlName());
             }
+
+            return action;
         }
+        return run.getAction(CoverityBuildAction.class);
     }
 }

--- a/src/test/java/jenkins/plugins/coverity/CoverityViewResultsPublisherTest.java
+++ b/src/test/java/jenkins/plugins/coverity/CoverityViewResultsPublisherTest.java
@@ -282,6 +282,237 @@ public class CoverityViewResultsPublisherTest {
                 "[Coverity] Coverity issues were found and abortPipeline was set to true, throwing abort exception");
     }
 
+    @Test
+    public void perform_withNoIssues_withMultiNoIssues_logsSuccess() throws IOException, InterruptedException {
+        final String instance = cimInstance.getName();
+        final String projectId = "projectId";
+        final String viewMulti = "viewMulti";
+        final String view = "view";
+
+        setupRunToHandleBuildAction();
+        TaskListener multiListener = mock(TaskListener.class); //mock out and ignore the result of the secondary view
+        setupIssues(viewMulti, 0);
+        setupIssues(view, 0);
+        final CoverityViewResultsPublisher publisherMulti = new CoverityViewResultsPublisher(instance, viewMulti, projectId);
+        final CoverityViewResultsPublisher publisher = new CoverityViewResultsPublisher(instance, view, projectId);
+
+        publisherMulti.perform(run, workspace, launcher, multiListener);
+        publisher.perform(run, workspace, launcher, listener);
+
+        consoleLogger.verifyMessages(
+            getInformationMessage(instance, projectId, view),
+            getRetrievingMessage(projectId, view),
+            getIssueCountMessage(0, projectId, view),
+            expectedUrlMessage,
+            expectedFinishedMessage);
+    }
+
+    @Test
+    public void perform_withIssues_withMultiNoIssues_logsSuccess() throws IOException, InterruptedException {
+        final String instance = cimInstance.getName();
+        final String projectId = "projectId";
+        final String viewMulti = "viewMulti";
+        final String view = "view";
+
+        setupRunToHandleBuildAction();
+        TaskListener multiListener = mock(TaskListener.class); //mock out and ignore the result of the secondary view
+        setupIssues(viewMulti, 0);
+        setupIssues(view, 10);
+        final CoverityViewResultsPublisher publisherMulti = new CoverityViewResultsPublisher(instance, viewMulti, projectId);
+        final CoverityViewResultsPublisher publisher = new CoverityViewResultsPublisher(instance, view, projectId);
+
+        publisherMulti.perform(run, workspace, launcher, multiListener);
+        publisher.perform(run, workspace, launcher, listener);
+
+        consoleLogger.verifyMessages(getInformationMessage(instance, projectId, view),
+            getRetrievingMessage(projectId, view),
+            getIssueCountMessage(10, projectId, view),
+            expectedUrlMessage,
+            expectedFinishedMessage);
+    }
+
+    @Test
+    public void perform_withIssues_withMultiIssues_logsSuccess() throws IOException, InterruptedException {
+        final String instance = cimInstance.getName();
+        final String projectId = "projectId";
+        final String viewMulti = "viewMulti";
+        final String view = "view";
+
+        setupRunToHandleBuildAction();
+        TaskListener multiListener = mock(TaskListener.class); //mock out and ignore the result of the secondary view
+        setupIssues(viewMulti, 15);
+        setupIssues(view, 10);
+        final CoverityViewResultsPublisher publisherMulti = new CoverityViewResultsPublisher(instance, viewMulti, projectId);
+        final CoverityViewResultsPublisher publisher = new CoverityViewResultsPublisher(instance, view, projectId);
+
+        publisherMulti.perform(run, workspace, launcher, multiListener);
+        publisher.perform(run, workspace, launcher, listener);
+
+        consoleLogger.verifyMessages(getInformationMessage(instance, projectId, view),
+            getRetrievingMessage(projectId, view),
+            getIssueCountMessage(10, projectId, view),
+            expectedUrlMessage,
+            expectedFinishedMessage);
+    }
+
+    @Test
+    public void perform_failPipeline_withIssues_withMultiIssues() throws IOException, InterruptedException {
+        final String instance = cimInstance.getName();
+        final String projectId = "projectId";
+        final String viewMulti = "viewMulti";
+        final String view = "view";
+        final boolean failPipeline = true;
+
+        setupRunToHandleBuildAction();
+        TaskListener multiListener = mock(TaskListener.class); //mock out and ignore the result of the secondary view
+        setupIssues(viewMulti, 15);
+        setupIssues(view, 10);
+        final CoverityViewResultsPublisher publisherMulti = new CoverityViewResultsPublisher(instance, viewMulti, projectId);
+        final CoverityViewResultsPublisher publisher = new CoverityViewResultsPublisher(instance, view, projectId);
+        publisher.setFailPipeline(failPipeline);
+
+        publisherMulti.perform(run, workspace, launcher, multiListener);
+        publisher.perform(run, workspace, launcher, listener);
+
+        consoleLogger.verifyMessages(getInformationMessage(instance, projectId, view),
+            getRetrievingMessage(projectId, view),
+            getIssueCountMessage(10, projectId, view),
+            expectedUrlMessage,
+            "[Coverity] Coverity issues were found and failPipeline was set to true, the pipeline result will be marked as FAILURE.",
+            expectedFinishedMessage);
+        verify(run).setResult(Result.FAILURE);
+    }
+
+    @Test
+    public void perform_failPipeline_withIssues_withMultiNoIssues() throws IOException, InterruptedException {
+        final String instance = cimInstance.getName();
+        final String projectId = "projectId";
+        final String viewMulti = "viewMulti";
+        final String view = "view";
+        final boolean failPipeline = true;
+
+        setupRunToHandleBuildAction();
+        TaskListener multiListener = mock(TaskListener.class); //mock out and ignore the result of the secondary view
+        setupIssues(viewMulti, 0);
+        setupIssues(view, 10);
+        final CoverityViewResultsPublisher publisherMulti = new CoverityViewResultsPublisher(instance, viewMulti, projectId);
+        final CoverityViewResultsPublisher publisher = new CoverityViewResultsPublisher(instance, view, projectId);
+        publisher.setFailPipeline(failPipeline);
+
+        publisherMulti.perform(run, workspace, launcher, multiListener);
+        publisher.perform(run, workspace, launcher, listener);
+
+        consoleLogger.verifyMessages(getInformationMessage(instance, projectId, view),
+            getRetrievingMessage(projectId, view),
+            getIssueCountMessage(10, projectId, view),
+            expectedUrlMessage,
+            "[Coverity] Coverity issues were found and failPipeline was set to true, the pipeline result will be marked as FAILURE.",
+            expectedFinishedMessage);
+        verify(run).setResult(Result.FAILURE);
+    }
+
+    @Test
+    public void perform_unstablePipeline_withIssues_withMultiIssues() throws IOException, InterruptedException {
+        final String instance = cimInstance.getName();
+        final String projectId = "projectId";
+        final String viewMulti = "viewMulti";
+        final String view = "view";
+        final boolean unstablePipeline = true;
+
+        setupRunToHandleBuildAction();
+        TaskListener multiListener = mock(TaskListener.class); //mock out and ignore the result of the secondary view
+        setupIssues(viewMulti, 15);
+        setupIssues(view, 20);
+        final CoverityViewResultsPublisher publisherMulti = new CoverityViewResultsPublisher(instance, viewMulti, projectId);
+        final CoverityViewResultsPublisher publisher = new CoverityViewResultsPublisher(instance, view, projectId);
+        publisher.setUnstable(unstablePipeline);
+
+        publisherMulti.perform(run, workspace, launcher, multiListener);
+        publisher.perform(run, workspace, launcher, listener);
+
+        consoleLogger.verifyMessages(getInformationMessage(instance, projectId, view),
+            getRetrievingMessage(projectId, view),
+            getIssueCountMessage(20, projectId, view),
+            expectedUrlMessage,
+            "[Coverity] Coverity issues were found and unstable was set to true, the pipeline result will be marked as UNSTABLE.",
+            expectedFinishedMessage);
+        verify(run).setResult(Result.UNSTABLE);
+    }
+
+    @Test
+    public void perform_unstablePipeline_withIssues_withMultiNoIssues() throws IOException, InterruptedException {
+        final String instance = cimInstance.getName();
+        final String projectId = "projectId";
+        final String viewMulti = "viewMulti";
+        final String view = "view";
+        final boolean unstablePipeline = true;
+
+        setupRunToHandleBuildAction();
+        TaskListener multiListener = mock(TaskListener.class); //mock out and ignore the result of the secondary view
+        setupIssues(viewMulti, 0);
+        setupIssues(view, 20);
+        final CoverityViewResultsPublisher publisherMulti = new CoverityViewResultsPublisher(instance, viewMulti, projectId);
+        final CoverityViewResultsPublisher publisher = new CoverityViewResultsPublisher(instance, view, projectId);
+        publisher.setUnstable(unstablePipeline);
+
+        publisherMulti.perform(run, workspace, launcher, multiListener);
+        publisher.perform(run, workspace, launcher, listener);
+
+        consoleLogger.verifyMessages(getInformationMessage(instance, projectId, view),
+            getRetrievingMessage(projectId, view),
+            getIssueCountMessage(20, projectId, view),
+            expectedUrlMessage,
+            "[Coverity] Coverity issues were found and unstable was set to true, the pipeline result will be marked as UNSTABLE.",
+            expectedFinishedMessage);
+        verify(run).setResult(Result.UNSTABLE);
+    }
+
+    @Test(expected = AbortException.class)
+    public void perform_abortPipeline_withIssues_withMultiIssues() throws IOException, InterruptedException {
+        final String instance = cimInstance.getName();
+        final String projectId = "projectId";
+        final String viewMulti = "viewMulti";
+        final String view = "view";
+        final boolean abortPipeline = true;
+
+        setupRunToHandleBuildAction();
+        TaskListener multiListener = mock(TaskListener.class); //mock out and ignore the result of the secondary view
+        setupIssues(viewMulti, 15);
+        setupIssues(view, 10);
+        final CoverityViewResultsPublisher publisherMulti = new CoverityViewResultsPublisher(instance, viewMulti, projectId);
+        final CoverityViewResultsPublisher publisher = new CoverityViewResultsPublisher(instance, view, projectId);
+        publisher.setAbortPipeline(abortPipeline);
+
+        publisherMulti.perform(run, workspace, launcher, multiListener);
+        publisher.perform(run, workspace, launcher, listener);
+
+        consoleLogger.verifyMessages(getInformationMessage(instance, projectId, view),
+                "[Coverity] Coverity issues were found and abortPipeline was set to true, throwing abort exception");
+    }
+
+    @Test(expected = AbortException.class)
+    public void perform_abortPipeline_withIssues_withMultiNoIssues() throws IOException, InterruptedException {
+        final String instance = cimInstance.getName();
+        final String projectId = "projectId";
+        final String viewMulti = "viewMulti";
+        final String view = "view";
+        final boolean abortPipeline = true;
+
+        setupRunToHandleBuildAction();
+        TaskListener multiListener = mock(TaskListener.class); //mock out and ignore the result of the secondary view
+        setupIssues(viewMulti, 0);
+        setupIssues(view, 10);
+        final CoverityViewResultsPublisher publisherMulti = new CoverityViewResultsPublisher(instance, viewMulti, projectId);
+        final CoverityViewResultsPublisher publisher = new CoverityViewResultsPublisher(instance, view, projectId);
+        publisher.setAbortPipeline(abortPipeline);
+
+        publisherMulti.perform(run, workspace, launcher, multiListener);
+        publisher.perform(run, workspace, launcher, listener);
+
+        consoleLogger.verifyMessages(getInformationMessage(instance, projectId, view),
+                "[Coverity] Coverity issues were found and abortPipeline was set to true, throwing abort exception");
+    }
+
     public void setupIssues(String view, int count) {
         final StringBuilder viewContentsApiJsonResult = new StringBuilder("{\"viewContentsV1\": {" +
             "    \"offset\": 0," +


### PR DESCRIPTION
Resolved an issue in the case where multiple Coverity runs are performed on a single Jenkins run. In this scenario `run.getAction(CoverityBuildAction.class)` will return the first instance (or first Coverity run performed). This results in unexpected behavior when paired with the fail/abort/unstable pipeline on defect feature.

Includes:
- 9 scenario tests
- Above scenario code fix to CoverityViewResultsPublisher.java and ViewIssuesReader.java
- VSCode .gitignores