### PR TITLE
Remove usages of Guava

### DIFF
--- a/src/main/java/jenkins/plugins/coverity/CIMInstance.java
+++ b/src/main/java/jenkins/plugins/coverity/CIMInstance.java
@@ -46,8 +46,6 @@ import com.coverity.ws.v9.RoleDataObj;
 import com.coverity.ws.v9.StreamDataObj;
 import com.coverity.ws.v9.StreamFilterSpecDataObj;
 import com.coverity.ws.v9.UserDataObj;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSortedMap;
 
 import hudson.security.ACL;
 import hudson.util.FormValidation;
@@ -266,25 +264,25 @@ public class CIMInstance {
         }
     }
 
-    public ImmutableList<String> getCimInstanceCheckers() throws IOException, CovRemoteServiceException_Exception {
+    public List<String> getCimInstanceCheckers() throws IOException, CovRemoteServiceException_Exception {
         final List<String> checkerNames = this.getConfigurationService().getCheckerNames();
         Collections.sort(checkerNames);
 
-        return ImmutableList.copyOf(checkerNames);
+        return Collections.unmodifiableList(new ArrayList<>(checkerNames));
     }
 
     /**
      * Returns a Map of available Coverity connect views for this instance, using the numeric identifier as the key
      * and name as value
      */
-    public ImmutableSortedMap<Long, String> getViews() {
+    public Map<Long, String> getViews() {
         Map<? extends Long, ? extends String> views;
         try {
             views = WebServiceFactory.getInstance().getViewService(this).getViews();
         } catch (MalformedURLException | NoSuchAlgorithmException | KeyManagementException e) {
-            return ImmutableSortedMap.of();
+            return Collections.emptyMap();
         }
-        return ImmutableSortedMap.copyOf(views);
+        return Collections.unmodifiableMap(new TreeMap<>(views));
     }
 
     public List<CoverityDefect> getIssuesVorView(String projectId, String connectView, PrintStream outputLogger) throws Exception {

--- a/src/main/java/jenkins/plugins/coverity/CoverityViewResultsDescriptor.java
+++ b/src/main/java/jenkins/plugins/coverity/CoverityViewResultsDescriptor.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
@@ -22,7 +23,6 @@ import org.kohsuke.stapler.QueryParameter;
 import com.coverity.ws.v9.CovRemoteServiceException_Exception;
 import com.coverity.ws.v9.ProjectDataObj;
 import com.coverity.ws.v9.ProjectFilterSpecDataObj;
-import com.google.common.collect.ImmutableSortedMap;
 
 import hudson.Extension;
 import hudson.model.AbstractProject;
@@ -145,7 +145,7 @@ public class CoverityViewResultsDescriptor extends BuildStepDescriptor<Publisher
         }
 
         try {
-            final ImmutableSortedMap<Long, String> views = instance.getViews();
+            final Map<Long, String> views = instance.getViews();
 
             // first check if any view names match connectView value
             if (!views.containsValue(connectView)) {

--- a/src/test/java/jenkins/plugins/coverity/CIMInstanceTest.java
+++ b/src/test/java/jenkins/plugins/coverity/CIMInstanceTest.java
@@ -52,7 +52,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.coverity.ws.v9.CovRemoteServiceException_Exception;
 import com.coverity.ws.v9.StreamDataObj;
-import com.google.common.collect.ImmutableSortedMap;
 
 import hudson.util.FormValidation;
 import hudson.util.FormValidation.Kind;
@@ -468,7 +467,7 @@ public class CIMInstanceTest {
         CIMInstance cimInstance = new CIMInstanceBuilder().withName("instance").withHost("host").withPort(8080)
                 .withUseSSL(false).withDefaultCredentialId().build();
 
-        final ImmutableSortedMap<Long, String> result = cimInstance.getViews();
+        final Map<Long, String> result = cimInstance.getViews();
 
         assertEquals(1, result.size());
         assertTrue(result.containsKey(Long.valueOf(67890)));
@@ -484,7 +483,7 @@ public class CIMInstanceTest {
         CIMInstance cimInstance = new CIMInstanceBuilder().withName("instance").withHost("host").withPort(8080)
                 .withUseSSL(true).withDefaultCredentialId().build();
 
-        final ImmutableSortedMap<Long, String> result = cimInstance.getViews();
+        final Map<Long, String> result = cimInstance.getViews();
 
         assertEquals(0, result.size());
     }


### PR DESCRIPTION
Replacing usages of Guava with native Java Platform equivalents to slim down the dependency tree of this plugin.