### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/src/main/resources/jenkins/plugins/coverity/CoverityPublisher/config.jelly
+++ b/src/main/resources/jenkins/plugins/coverity/CoverityPublisher/config.jelly
@@ -10,7 +10,7 @@
  *    Synopsys, Inc - initial implementation and documentation
  *******************************************************************************/
 -->
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:c="/lib/credentials" xmlns:l="/lib/layout">
     <j:set var="javaOption" value="${instance.javaOptionBlock}"/>
 	<script type="text/javascript">
     document.observe("dom:loaded", function() {
@@ -398,7 +398,7 @@
 									<td class="setting-help">
 										<a href="#" class="help-button"
 										   helpURL="${rootURL}/descriptor/jenkins.plugins.coverity.CoverityPublisher/help/defectFilters">
-											<img src="${imagesURL}/16x16/help.gif" alt="Help for feature: ${title}"/>
+											<l:icon class="icon-help icon-sm" alt="Help for feature: ${title}"/>
 										</a>
 									</td>
 									<f:helpArea/>
@@ -854,7 +854,7 @@
 					<td class="setting-help">
 						<a href="#" class="help-button"
 						   helpURL="${rootURL}/descriptor/jenkins.plugins.coverity.CoverityPublisher/help/failBuild">
-							<img src="${imagesURL}/16x16/help.gif" alt="Help for feature: ${title}"/>
+                            <l:icon class="icon-help icon-sm" alt="Help for feature: ${title}"/>
 						</a>
 					</td>
 				</tr>
@@ -867,7 +867,7 @@
 					<td class="setting-help">
 						<a href="#" class="help-button"
 						   helpURL="${rootURL}/descriptor/jenkins.plugins.coverity.CoverityPublisher/help/unstable">
-							<img src="${imagesURL}/16x16/help.gif" alt="Help for feature: ${title}"/>
+                            <l:icon class="icon-help icon-sm" alt="Help for feature: ${title}"/>
 						</a>
 					</td>
 				</tr>
@@ -880,7 +880,7 @@
 					<td class="setting-help">
 						<a href="#" class="help-button"
 						   helpURL="${rootURL}/descriptor/jenkins.plugins.coverity.CoverityPublisher/help/skipFetchingDefects">
-							<img src="${imagesURL}/16x16/help.gif" alt="Help for feature: ${title}"/>
+                            <l:icon class="icon-help icon-sm" alt="Help for feature: ${title}"/>
 						</a>
 					</td>
 				</tr>
@@ -893,7 +893,7 @@
 					<td class="setting-help">
 						<a href="#" class="help-button"
 						   helpURL="${rootURL}/descriptor/jenkins.plugins.coverity.CoverityPublisher/help/keepIntDir">
-							<img src="${imagesURL}/16x16/help.gif" alt="Help for feature: ${title}"/>
+                            <l:icon class="icon-help icon-sm" alt="Help for feature: ${title}"/>
 						</a>
 					</td>
 				</tr>
@@ -906,7 +906,7 @@
 					<td class="setting-help">
 						<a href="#" class="help-button"
 						   helpURL="${rootURL}/descriptor/jenkins.plugins.coverity.CoverityPublisher/help/hideChart">
-							<img src="${imagesURL}/16x16/help.gif" alt="Help for feature: ${title}"/>
+                            <l:icon class="icon-help icon-sm" alt="Help for feature: ${title}"/>
 						</a>
 					</td>
 				</tr>


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @ahcho0819
Thanks in advance!